### PR TITLE
[NCL-6736] Mark build as SYSTEM_ERROR if Indy refused connection

### DIFF
--- a/src/test/java/org/jboss/pnc/builddriver/DriverTest.java
+++ b/src/test/java/org/jboss/pnc/builddriver/DriverTest.java
@@ -1,0 +1,45 @@
+package org.jboss.pnc.builddriver;
+
+import org.jboss.pnc.buildagent.api.Status;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DriverTest {
+
+    @Test
+    void overrideStatusFromLogsWhenIndyConnectionRefused() {
+        // change to SYSTEM_ERROR
+        StringBuilder builder = new StringBuilder();
+        builder.append(
+                "Connect to indy.test.svc.cluster.local:80 [indy.test.svc.cluster.local] failed: Connection refused (Connection refused)");
+        Status updated = Driver.overrideStatusFromLogs(builder, Status.FAILED);
+        assertSame(Status.SYSTEM_ERROR, updated);
+
+        StringBuilder another = new StringBuilder();
+        another.append(
+                "Connect to indy.example.com:443 [indy.example.com] failed: Connection refused (Connection refused)");
+        updated = Driver.overrideStatusFromLogs(builder, Status.FAILED);
+        assertSame(Status.SYSTEM_ERROR, updated);
+    }
+
+    /**
+     * If the status is not set to FAILED, then Driver.overrideStatusFromLogs shouldn't change the status
+     */
+    @Test
+    void noOverrideStatusFromLogsForIndyWhenStatusNotFailed() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(
+                "Connect to indy.test.svc.cluster.local:80 [indy.test.svc.cluster.local] failed: Connection refused (Connection refused)");
+        Status updated = Driver.overrideStatusFromLogs(builder, Status.COMPLETED);
+        assertSame(Status.COMPLETED, updated);
+    }
+
+    @Test
+    void noOverrideStatusFromLogsWhenNoMatchForIndy() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Everything went fine. Except all that 5G waves");
+        Status updated = Driver.overrideStatusFromLogs(builder, Status.FAILED);
+        assertSame(Status.FAILED, updated);
+    }
+}


### PR DESCRIPTION
If the build logs contains:
```
Connection to indy.<url>[..] failed. Connection refused
```

and the original build agent status is 'FAILED', override that status to
'SYSTEM_ERROR'.

The implementation is written so that more override status logic can be added
into the Driver method down the line based on the builder logs.