### PR TITLE
Downgrade Quarkus to 2.10.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
   <properties>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
     <maven.compiler.target>11</maven.compiler.target>
-    <quarkus.platform.version>2.12.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.10.4.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>


### PR DESCRIPTION
This is the last version that uploads uber jars to Maven Central. The issue with the latest Quarkus version will be fixed in a future release.