### PR TITLE
Shallow clone depth of git repository to build

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,9 +47,8 @@ build-driver:
     echo 'cd %{workingDirectory}/%{projectName}' >> $${HOME}/.bashrc
     set -xe
     cd %{workingDirectory}
-    git clone %{scmUrl} %{projectName}
+    git clone --branch %{scmRevision} --depth 1 %{scmUrl} %{projectName}
     cd %{projectName}
-    git reset --hard %{scmRevision}
     %{command}
 
 "%test":


### PR DESCRIPTION
This should save us time cloning the repository and lighten the load on the Gerrit server