### PR TITLE
[NCLSUP-792] Check that revision and tag matches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>pnc-api</artifactId>
-      <version>2.4.1</version>
+      <version>2.4.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc.logging</groupId>

--- a/src/main/java/org/jboss/pnc/builddriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/builddriver/Driver.java
@@ -168,6 +168,7 @@ public class Driver {
                 buildRequest.getProjectName(),
                 buildRequest.getScmUrl(),
                 buildRequest.getScmRevision(),
+                buildRequest.getScmTag(),
                 buildRequest.getCommand());
         logger.info("Build script: {}", buildScript);
         Path runScriptPath = Paths.get(workingDirectory, "/run.sh");
@@ -409,12 +410,14 @@ public class Driver {
             String projectName,
             String scmUrl,
             String scmRevision,
+            String scmTag,
             String buildCommand) {
         Map<String, String> values = new HashMap<>();
         values.put("workingDirectory", workingDirectory);
         values.put("projectName", projectName);
         values.put("scmUrl", scmUrl);
         values.put("scmRevision", scmRevision);
+        values.put("scmTag", scmTag);
         values.put("command", buildCommand);
         return StringSubstitutor.replace(scriptTemplate, values, "%{", "}");
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,8 +47,14 @@ build-driver:
     echo 'cd %{workingDirectory}/%{projectName}' >> $${HOME}/.bashrc
     set -xe
     cd %{workingDirectory}
-    git clone --branch %{scmRevision} --depth 1 %{scmUrl} %{projectName}
+    git clone --branch %{scmTag} --depth 1 %{scmUrl} %{projectName}
     cd %{projectName}
+    git_commit_id="$(git rev-parse HEAD)"
+    if [[ "%{scmRevision}" != "${git_commit_id}" ]]; then
+      echo "[ERROR] SCM Revision of request doesn't match the commit id from the scm tag"
+      echo "[ERROR] Aborting!"
+      exit 1
+    fi
     %{command}
 
 "%test":

--- a/src/test/java/org/jboss/pnc/builddriver/BuildDriverTest.java
+++ b/src/test/java/org/jboss/pnc/builddriver/BuildDriverTest.java
@@ -115,6 +115,7 @@ public class BuildDriverTest {
                 "the-build",
                 "not-used",
                 "not-used",
+                "not-used",
                 "exit 0",
                 workingDirectory.toString(),
                 baseBuildAgentUri.toString(),
@@ -155,6 +156,7 @@ public class BuildDriverTest {
 
         BuildRequest buildRequest = new BuildRequest(
                 "the-build",
+                "not-used",
                 "not-used",
                 "not-used",
                 "for i in {1..3}; do echo \"Sleeping $i times\"; sleep 1; done",
@@ -237,6 +239,7 @@ public class BuildDriverTest {
         String command = "set +ex\n" + "cat /tmp/log-100MB.log;" + "sleep 5;";
         BuildRequest buildRequest = new BuildRequest(
                 "the-build",
+                "not-used",
                 "not-used",
                 "not-used",
                 command,


### PR DESCRIPTION
We want to add a check to make sure that the commit id that the tag we clones matches the scm revision from the caller.