### PR TITLE
[NCLSUP-900] Add the progress flag on git clone

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,7 +47,7 @@ build-driver:
     echo 'cd %{workingDirectory}/%{projectName}' >> $${HOME}/.bashrc
     set -xe
     cd %{workingDirectory}
-    git clone --branch %{scmTag} --depth 1 %{scmUrl} %{projectName}
+    git clone --progress --branch %{scmTag} --depth 1 %{scmUrl} %{projectName}
     cd %{projectName}
     git_commit_id="$(git rev-parse HEAD)"
     if [[ "%{scmRevision}" != "\${git_commit_id}" ]]; then


### PR DESCRIPTION
If the progress flag is not set, the Gerrit backend doesn't send data to the git client via the Gerrit frontend proxy.

THe Gerrit frontend proxy doesn't see any dataflow in 1 minute breaks the connection with a HTTP 502 error.

The progress flag forces the flow of data and tricks the Gerrit frontend proxy to believe that stuff is happening and keep the connection alive.