### PR TITLE
[NCL-8052] Update build-driver to use its own service token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,10 @@
       <artifactId>quarkus-oidc</artifactId>
     </dependency>
     <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-oidc-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-keycloak-authorization</artifactId>
     </dependency>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,6 +36,12 @@ quarkus:
     keycloak:
       policy-enforcer:
         enable: false
+  oidc-client:
+    auth-server-url: https://keycloak-host/auth/realms/my-realm
+    client-id: my-client-id
+    credentials:
+      secret: hey
+
 build-driver:
   self-base-url: http://this-service-host-for-a-callback/
   script-template: |
@@ -61,6 +67,8 @@ build-driver:
       %{command}
   quarkus:
     oidc:
+      enabled: false
+    oidc-client:
       enabled: false
     log:
       console:

--- a/src/test/java/org/jboss/pnc/builddriver/BeanMockFactory.java
+++ b/src/test/java/org/jboss/pnc/builddriver/BeanMockFactory.java
@@ -1,0 +1,14 @@
+package org.jboss.pnc.builddriver;
+
+import io.quarkus.oidc.client.Tokens;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class BeanMockFactory {
+
+    @Produces
+    public Tokens getTokens() {
+        return new Tokens("abcd", 0L, null, "abcd", 0L, null);
+    }
+}


### PR DESCRIPTION
This commit adds support for oidc-client, where we'll use our own service account to submit requests to build-agent.

For now, this commit doesn't remove the hardcoded authentication http header in the callback. This will be removed once build-agent injects its own access token to the callback.