### PR TITLE
[v1.1.x][NCL-8101] Specify roles for REST endpoints

### DIFF
--- a/src/main/java/org/jboss/pnc/builddriver/endpoints/Internal.java
+++ b/src/main/java/org/jboss/pnc/builddriver/endpoints/Internal.java
@@ -18,12 +18,12 @@
 
 package org.jboss.pnc.builddriver.endpoints;
 
-import io.quarkus.security.Authenticated;
 import org.jboss.pnc.buildagent.api.TaskStatusUpdateEvent;
 import org.jboss.pnc.builddriver.Driver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
@@ -54,7 +54,7 @@ public class Internal {
      * @param updateEvent
      * @return
      */
-    @Authenticated
+    @RolesAllowed({ "pnc-users-build-driver-admin", "pnc-users-admin" })
     @PUT
     @Path("/completed")
     public CompletionStage<Void> buildExecutionCompleted(TaskStatusUpdateEvent updateEvent) {

--- a/src/main/java/org/jboss/pnc/builddriver/endpoints/Public.java
+++ b/src/main/java/org/jboss/pnc/builddriver/endpoints/Public.java
@@ -18,7 +18,6 @@
 
 package org.jboss.pnc.builddriver.endpoints;
 
-import io.quarkus.security.Authenticated;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.pnc.api.builddriver.dto.BuildCancelRequest;
 import org.jboss.pnc.api.builddriver.dto.BuildRequest;
@@ -29,6 +28,7 @@ import org.jboss.pnc.builddriver.Driver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -58,7 +58,7 @@ public class Public {
      * Triggers the build execution for a given configuration. Method returns when the build is running in a remote
      * build environment.
      */
-    @Authenticated
+    @RolesAllowed({ "pnc-users-build-driver-admin", "pnc-users-admin" })
     @POST
     @Path("/build")
     public CompletionStage<BuildResponse> build(BuildRequest buildRequest) {
@@ -69,7 +69,7 @@ public class Public {
     /**
      * Cancel the build execution.
      */
-    @Authenticated
+    @RolesAllowed({ "pnc-users-build-driver-admin", "pnc-users-admin" })
     @PUT
     @Path("/cancel")
     public CompletionStage<Response> cancel(BuildCancelRequest buildCancelRequest) {


### PR DESCRIPTION
As part of the Authorization work, we need to restrict who can access the build-driver endpoints that could cause catastrophic situations.

With that in mind, the 2 roles we allow users to do stuff is:

- pnc-users-build-driver-admin: service accounts that need to talk to build-driver
- pnc-users-admin: pnc developers that will have "god" permissions