### PR TITLE
Bump version to 3.5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.pnc</groupId>
   <artifactId>build-driver</artifactId>
-  <version>3.3.2-SNAPSHOT</version>
+  <version>3.5.0-SNAPSHOT</version>
 
   <name>build-driver</name>
   <description>Stateless build driver</description>


### PR DESCRIPTION
Version bumping to 3.5.0, so that it's aligned with most of PNC components.